### PR TITLE
Fixed bug in FloatCubic.Round()

### DIFF
--- a/HexGrid/Logical/FloatCubic.cs
+++ b/HexGrid/Logical/FloatCubic.cs
@@ -6,9 +6,9 @@ using System.Text;
 namespace ca.axoninteractive.Geometry.Hex
 {
 	/// <summary>
-	/// FloatCubic represents a pseudo-position on the hex grid. It does not directly represent 
-	/// the position of a hex, but instead is used as a means to compute a hex position by rounding 
-	/// a FloatCubic using CubicHexCoord.Round(), which returns a CubicHexCoord. 
+	/// FloatCubic represents a pseudo-position on the hex grid. It does not directly represent
+	/// the position of a hex, but instead is used as a means to compute a hex position by rounding
+	/// a FloatCubic using CubicHexCoord.Round(), which returns a CubicHexCoord.
 	/// </summary>
 	public struct FloatCubic
 	{
@@ -19,31 +19,31 @@ namespace ca.axoninteractive.Geometry.Hex
 		public float z;
 
 		#endregion
-		
-		
+
+
 		#region Constructors
-		
+
 		/// <summary>
 		/// Create a new FloatCubic given a CubicHexIndex.
 		/// </summary>
 		/// <param name="cubic">Any CubicHexCoord representing a hex.</param>
-		public 
-		FloatCubic( CubicHexCoord cubic ) 
+		public
+		FloatCubic( CubicHexCoord cubic )
 		{
 			this.x = (float)cubic.x;
 			this.y = (float)cubic.y;
 			this.z = (float)cubic.z;
 		}
-		
-		
+
+
 		/// <summary>
 		/// Create a new FloatCubic given the coordinates x, y and z.
 		/// </summary>
 		/// <param name="x">The position on this point on the x-axis.</param>
 		/// <param name="y">The position on this point on the y-axis.</param>
 		/// <param name="z">The position on this point on the z-axis.</param>
-		public 
-		FloatCubic( float x, float y, float z ) 
+		public
+		FloatCubic( float x, float y, float z )
 		{
 			this.x = x;
 			this.y = y;
@@ -51,16 +51,16 @@ namespace ca.axoninteractive.Geometry.Hex
 		}
 
 		#endregion
-		
-		
+
+
 		#region Type Conversions
-		
+
 		/// <summary>
 		/// Return this FloatCubic as a FloatAxial.
 		/// </summary>
 		/// <returns>A FloatAxial representing this FloatCubic.</returns>
-		public 
-		FloatAxial 
+		public
+		FloatAxial
 		ToFloatAxial()
 		{
 			float q = this.x;
@@ -70,15 +70,15 @@ namespace ca.axoninteractive.Geometry.Hex
 		}
 
 		#endregion
-		
-		
+
+
 		#region Instance Methods
-		
+
 		/// <summary>
 		/// Returns a new CubicHexCoord representing the nearest hex to this FloatCubic.
 		/// </summary>
 		/// <returns>A new CubicHexCoord representing the nearest hex to this FloatCubic.</returns>
-		public 
+		public
 		CubicHexCoord
 		Round()
 		{
@@ -86,9 +86,9 @@ namespace ca.axoninteractive.Geometry.Hex
 			int ry = (int)Math.Round( this.y );
 			int rz = (int)Math.Round( this.z );
 
-			int xDiff = (int)Math.Abs( rx - this.x );
-			int yDiff = (int)Math.Abs( ry - this.y );
-			int zDiff = (int)Math.Abs( rz - this.z );
+			float xDiff = Math.Abs(rx - this.x);
+			float yDiff = Math.Abs(ry - this.y);
+			float zDiff = Math.Abs(rz - this.z);
 
 			if ( xDiff > yDiff && xDiff > zDiff )
 			{
@@ -108,14 +108,14 @@ namespace ca.axoninteractive.Geometry.Hex
 
 
 		/// <summary>
-		/// Scale the world space by the given factor, causing q and r to change proportionally 
+		/// Scale the world space by the given factor, causing q and r to change proportionally
 		/// to factor.
 		/// </summary>
-		/// <param name="factor">The multiplicative factor by which the world space is being 
+		/// <param name="factor">The multiplicative factor by which the world space is being
 		/// scaled.</param>
 		/// <returns>A new FloatCubic representing the new floating hex position.</returns>
-		public 
-		FloatCubic 
+		public
+		FloatCubic
 		Scale( float factor )
 		{
 			return new FloatCubic(


### PR DESCRIPTION
The Round() method in FloatCubic class is implemented according to the original article: https://www.redblobgames.com/grids/hexagons/#rounding
But there was a bug with unnecessary rounding of coordinate components (_diff) whitch led to incorrect conversion of Cubic coordinates (including HexGrid.PointToCubic()).